### PR TITLE
feat: Add separate build job to CI workflow

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -45,3 +45,22 @@ jobs:
 
       - name: Run linter
         run: npm run lint # Or yarn lint
+
+  build:
+    name: Build Project
+    runs-on: ubuntu-latest
+    needs: [test, lint] # Optional: make build depend on test and lint passing
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20' # Or your project's Node.js version
+
+      - name: Install dependencies
+        run: npm install # Or yarn install
+
+      - name: Build project
+        run: npm run build


### PR DESCRIPTION
This change introduces a new 'build' job to the GitHub Actions CI workflow. This job is responsible for running `npm run build` to ensure your project builds successfully.

The build job runs after the 'test' and 'lint' jobs have completed successfully.